### PR TITLE
Enabled tlm-client to stay alive to keep "sessions" trackable

### DIFF
--- a/src/common/dbus/tlm-dbus-server-p2p.h
+++ b/src/common/dbus/tlm-dbus-server-p2p.h
@@ -66,10 +66,20 @@ GType
 tlm_dbus_server_p2p_get_type();
 
 void
-tlm_dbus_server_p2p_add_adaptor_object (
+tlm_dbus_server_p2p_add_dbus_adaptor (
         TlmDbusServerP2P *server,
         GDBusConnection *connection,
         GObject *adaptor_object);
+
+void
+tlm_dbus_server_p2p_remove_dbus_adaptor (
+        TlmDbusServerP2P *server,
+        GDBusConnection *connection,
+        GObject *adaptor_object);
+
+GHashTable *
+tlm_dbus_server_p2p_get_dbus_adaptors (
+        TlmDbusServerP2P *server);
 
 TlmDbusServerP2P *
 tlm_dbus_server_p2p_new (

--- a/src/daemon/dbus/tlm-dbus-login-adapter.h
+++ b/src/daemon/dbus/tlm-dbus-login-adapter.h
@@ -72,6 +72,14 @@ TlmDbusLoginAdapter *
 tlm_dbus_login_adapter_new_with_connection (
         GDBusConnection *connection);
 
+GDBusConnection *
+tlm_dbus_login_adapter_get_connection (
+        TlmDbusLoginAdapter *self);
+
+const gchar *
+tlm_dbus_login_adapter_get_sessionid (
+        TlmDbusLoginAdapter *self);
+
 void
 tlm_dbus_login_adapter_request_completed (
         TlmDbusRequest *request,

--- a/src/daemon/tlm-dbus-observer.h
+++ b/src/daemon/tlm-dbus-observer.h
@@ -76,6 +76,12 @@ tlm_dbus_observer_new (
         uid_t uid,
         DbusObserverEnableFlags enable_flags);
 
+void
+tlm_dbus_observer_session_terminated (
+        TlmDbusObserver *self,
+        const gchar *sessionid,
+        TlmSeat *seat);
+
 G_END_DECLS
 
 #endif /* _TLM_DBUS_OBSERVER_H */

--- a/src/daemon/tlm-session-remote.c
+++ b/src/daemon/tlm-session-remote.c
@@ -100,7 +100,7 @@ _on_child_down_cb (
 
     TlmSessionRemote *session = TLM_SESSION_REMOTE (data);
 
-    DBG ("Sessiond(%p) with pid (%d) closed with status %d", session, pid,
+    DBG ("sessiond(%p) with pid (%d) closed with status %d", session, pid,
             status);
 
     session->priv->is_sessiond_up = FALSE;

--- a/src/launcher/tlm-process-manager.c
+++ b/src/launcher/tlm-process-manager.c
@@ -260,7 +260,7 @@ _handle_dbus_server_new_connection (
 
 	launcher_object = tlm_dbus_launcher_adapter_new_with_connection (self,
 	        dbus_connection);
-	tlm_dbus_server_p2p_add_adaptor_object (
+	tlm_dbus_server_p2p_add_dbus_adaptor (
 			TLM_DBUS_SERVER_P2P (self->priv->dbus_server),
 			dbus_connection, G_OBJECT(launcher_object));
 }


### PR DESCRIPTION
tlm-client needs to be taken down if dbus connection is closed
or some external entity send TERM/KILL signal to tlm-client.
Use case is that systemd needs to track session once initiated
using tlm-client, and that needs tlm-client running until
session is alive